### PR TITLE
feat: backport cloud-init from unstable debian

### DIFF
--- a/elements/kubernetes/finalise.d/97-backports
+++ b/elements/kubernetes/finalise.d/97-backports
@@ -8,11 +8,12 @@ fi
 set -eu
 set -o pipefail
 
-if [[ ${DISTRO_NAME} =~ (debian) ]]; then
-    # NOTE(fitbeard): For Debian Trixie backport 'cloud-init' from unstable to have a version
-    #                 that supports vlan and bond in networkd.
+if [[ ${DIB_RELEASE} =~ (trixie) ]]; then
+    # NOTE(fitbeard): For Debian Trixie backport 'cloud-init' from unstable snapshot
+    #                 to have a version that supports vlan and bond in networkd.
     #                 https://github.com/canonical/cloud-init/pull/6324
-    echo "deb http://deb.debian.org/debian unstable main" | tee /etc/apt/sources.list.d/unstable.list
+    apt install ca-certificates -y
+    echo "deb https://snapshot.debian.org/archive/debian/20251014T204255Z/ unstable main" | tee /etc/apt/sources.list.d/unstable.list
 
     cat <<EOF > /etc/apt/preferences.d/99pin-unstable
 Package: *


### PR DESCRIPTION
Closes:  https://github.com/vexxhost/capo-image-elements/issues/70

I thought about it and decided to stick with `networkd`. Because switching Debian to `ENI` means adding whole logic which replaces `networkd` (the default).
With this change we will have 25.2 on Ubuntu (out of the box) and Debian images.

Only RockyLinux stays on `cloud-init` 24.x and customized networking. And i like to leave it like this because `NetworkManager` is... complicated:)

A little bit of history: https://opendev.org/openstack/diskimage-builder/commit/4987b7dbc364b6067bfdaf3f701541f53e88f156