### PR TITLE
feat: set empty DIB_BOOTLOADER_DEFAULT_CMDLINE variable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,6 @@ jobs:
           DIB_MIN_TMPFS: "4"
           DIB_CLOUD_INIT_GROWPART_DEVICES: '["/"]'
           DIB_SKIP_BASE_PACKAGE_INSTALL: "1"
-          DIB_BOOTLOADER_DEFAULT_CMDLINE: " " # Avoid adding any default kernel options defined by diskimage-builder
           DIB_IMAGE_SIZE: "3" # Debian 2.5, Rocky 2.8, Ubuntu 2.8-3.0
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -173,6 +172,43 @@ jobs:
 
       - name: Wait for control plane to initialize
         run: kubectl wait --for=condition=ControlPlaneInitialized --timeout=120s cluster/test
+
+      - name: Verify control plane instance console log
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mapfile -t INSTANCE_IDS < <(openstack server list -f value -c ID)
+          if [ "${#INSTANCE_IDS[@]}" -ne 1 ]; then
+            echo "Expected exactly 1 OpenStack instance, found ${#INSTANCE_IDS[@]}:"
+            openstack server list
+            exit 1
+          fi
+          INSTANCE_ID="${INSTANCE_IDS[0]}"
+          echo "Instance ID: ${INSTANCE_ID}"
+
+          LOG=$(openstack console log show "${INSTANCE_ID}")
+          echo "----- console log -----"
+          echo "${LOG}"
+          echo "----- end console log -----"
+
+          if [ -z "${LOG//[[:space:]]/}" ]; then
+            echo "ERROR: console log is empty"
+            exit 1
+          fi
+
+          if ! grep -qE '^(Kernel command line|Command line):' <<<"${LOG}"; then
+            echo "ERROR: no kernel/command line entries found in console log"
+            exit 1
+          fi
+
+          BAD_TOKENS='nofb|nomodeset|gfxpayload=text'
+          if grep -E "^(Kernel command line|Command line):" <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
+            echo "ERROR: forbidden kernel cmdline tokens (${BAD_TOKENS}) found:"
+            grep -E "^(Kernel command line|Command line):" <<<"${LOG}" | grep -E "${BAD_TOKENS}"
+            exit 1
+          fi
+        env:
+          OS_CLOUD: devstack
 
       - name: Get workload cluster KUBECONFIG
         run: clusterctl get kubeconfig test > /tmp/kubeconfig

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,47 +173,6 @@ jobs:
       - name: Wait for control plane to initialize
         run: kubectl wait --for=condition=ControlPlaneInitialized --timeout=120s cluster/test
 
-      - name: Verify control plane instance console log
-        if: ${{ always() }}
-        run: |
-          set -euo pipefail
-          mapfile -t INSTANCE_IDS < <(openstack server list -f value -c ID)
-          if [ "${#INSTANCE_IDS[@]}" -ne 1 ]; then
-            echo "Expected exactly 1 OpenStack instance, found ${#INSTANCE_IDS[@]}:"
-            openstack server list
-            exit 1
-          fi
-          INSTANCE_ID="${INSTANCE_IDS[0]}"
-          echo "Instance ID: ${INSTANCE_ID}"
-
-          LOG=$(openstack console log show "${INSTANCE_ID}")
-          echo "----- console log -----"
-          echo "${LOG}"
-          echo "----- end console log -----"
-
-          if [ -z "${LOG//[[:space:]]/}" ]; then
-            echo "ERROR: console log is empty"
-            exit 1
-          fi
-
-          if ! grep -qE 'Kernel command line:' <<<"${LOG}"; then
-            echo "ERROR: no 'Kernel command line:' entry found in console log"
-            exit 1
-          fi
-          if ! grep -qE '(^|\] )Command line:' <<<"${LOG}"; then
-            echo "ERROR: no 'Command line:' entry found in console log"
-            exit 1
-          fi
-
-          BAD_TOKENS='nofb|nomodeset|gfxpayload=text'
-          if grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
-            echo "ERROR: forbidden kernel cmdline tokens (${BAD_TOKENS}) found:"
-            grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -E "${BAD_TOKENS}"
-            exit 1
-          fi
-        env:
-          OS_CLOUD: devstack
-
       - name: Get workload cluster KUBECONFIG
         run: clusterctl get kubeconfig test > /tmp/kubeconfig
 
@@ -262,6 +221,58 @@ jobs:
         run: kubectl wait --for=condition=Ready nodes --all --timeout=5m
         env:
           KUBECONFIG: /tmp/kubeconfig
+
+      - name: Verify OpenStack instance console logs
+        run: |
+          set -euo pipefail
+
+          mapfile -t PROVIDER_IDS < <(
+            kubectl get machines \
+              -l cluster.x-k8s.io/cluster-name=test \
+              -o jsonpath='{range .items[*]}{.spec.providerID}{"\n"}{end}'
+          )
+
+          if [ "${#PROVIDER_IDS[@]}" -eq 0 ]; then
+            echo "ERROR: no Machines found for cluster 'test'"
+            kubectl get machines -A
+            exit 1
+          fi
+
+          BAD_TOKENS='nofb|nomodeset|gfxpayload=text'
+          for provider_id in "${PROVIDER_IDS[@]}"; do
+            [ -n "${provider_id}" ] || continue
+            instance_id="${provider_id##*/}"
+
+            echo "Instance ID: ${instance_id} (providerID: ${provider_id})"
+            LOG=$(openstack console log show "${instance_id}")
+
+            if [ -z "${LOG//[[:space:]]/}" ]; then
+              echo "ERROR: console log is empty for instance ${instance_id}"
+              exit 1
+            fi
+
+            if ! grep -qE 'Kernel command line:' <<<"${LOG}"; then
+              echo "ERROR: no 'Kernel command line:' entry found in console log for instance ${instance_id}"
+              echo "${LOG}"
+              exit 1
+            fi
+            if ! grep -qE '(^|\] )Command line:' <<<"${LOG}"; then
+              echo "ERROR: no 'Command line:' entry found in console log for instance ${instance_id}"
+              echo "${LOG}"
+              exit 1
+            fi
+
+            if grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
+              echo "ERROR: forbidden kernel cmdline tokens (${BAD_TOKENS}) found for instance ${instance_id}:"
+              grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -E "${BAD_TOKENS}"
+              exit 1
+            fi
+
+            echo "Kernel cmdline entries:"
+            grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" || true
+          done
+        env:
+          OS_CLOUD: devstack
 
       - name: Start CI debugging on failures
         uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1.14.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,7 @@ jobs:
           DIB_MIN_TMPFS: "4"
           DIB_CLOUD_INIT_GROWPART_DEVICES: '["/"]'
           DIB_SKIP_BASE_PACKAGE_INSTALL: "1"
+          DIB_BOOTLOADER_DEFAULT_CMDLINE: " " # Avoid adding any default kernel options defined by diskimage-builder
           DIB_IMAGE_SIZE: "3" # Debian 2.5, Rocky 2.8, Ubuntu 2.8-3.0
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,15 +196,19 @@ jobs:
             exit 1
           fi
 
-          if ! grep -qE '^(Kernel command line|Command line):' <<<"${LOG}"; then
-            echo "ERROR: no kernel/command line entries found in console log"
+          if ! grep -qE 'Kernel command line:' <<<"${LOG}"; then
+            echo "ERROR: no 'Kernel command line:' entry found in console log"
+            exit 1
+          fi
+          if ! grep -qE '(^|\] )Command line:' <<<"${LOG}"; then
+            echo "ERROR: no 'Command line:' entry found in console log"
             exit 1
           fi
 
           BAD_TOKENS='nofb|nomodeset|gfxpayload=text'
-          if grep -E "^(Kernel command line|Command line):" <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
+          if grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
             echo "ERROR: forbidden kernel cmdline tokens (${BAD_TOKENS}) found:"
-            grep -E "^(Kernel command line|Command line):" <<<"${LOG}" | grep -E "${BAD_TOKENS}"
+            grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -E "${BAD_TOKENS}"
             exit 1
           fi
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,6 +173,47 @@ jobs:
       - name: Wait for control plane to initialize
         run: kubectl wait --for=condition=ControlPlaneInitialized --timeout=120s cluster/test
 
+      - name: Verify control plane instance console log
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mapfile -t INSTANCE_IDS < <(openstack server list -f value -c ID)
+          if [ "${#INSTANCE_IDS[@]}" -ne 1 ]; then
+            echo "Expected exactly 1 OpenStack instance, found ${#INSTANCE_IDS[@]}:"
+            openstack server list
+            exit 1
+          fi
+          INSTANCE_ID="${INSTANCE_IDS[0]}"
+          echo "Instance ID: ${INSTANCE_ID}"
+
+          LOG=$(openstack console log show "${INSTANCE_ID}")
+          echo "----- console log -----"
+          echo "${LOG}"
+          echo "----- end console log -----"
+
+          if [ -z "${LOG//[[:space:]]/}" ]; then
+            echo "ERROR: console log is empty"
+            exit 1
+          fi
+
+          if ! grep -qE 'Kernel command line:' <<<"${LOG}"; then
+            echo "ERROR: no 'Kernel command line:' entry found in console log"
+            exit 1
+          fi
+          if ! grep -qE '(^|\] )Command line:' <<<"${LOG}"; then
+            echo "ERROR: no 'Command line:' entry found in console log"
+            exit 1
+          fi
+
+          BAD_TOKENS='nofb|nomodeset|gfxpayload=text'
+          if grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
+            echo "ERROR: forbidden kernel cmdline tokens (${BAD_TOKENS}) found:"
+            grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -E "${BAD_TOKENS}"
+            exit 1
+          fi
+        env:
+          OS_CLOUD: devstack
+
       - name: Get workload cluster KUBECONFIG
         run: clusterctl get kubeconfig test > /tmp/kubeconfig
 
@@ -221,58 +262,6 @@ jobs:
         run: kubectl wait --for=condition=Ready nodes --all --timeout=5m
         env:
           KUBECONFIG: /tmp/kubeconfig
-
-      - name: Verify OpenStack instance console logs
-        run: |
-          set -euo pipefail
-
-          mapfile -t PROVIDER_IDS < <(
-            kubectl get machines \
-              -l cluster.x-k8s.io/cluster-name=test \
-              -o jsonpath='{range .items[*]}{.spec.providerID}{"\n"}{end}'
-          )
-
-          if [ "${#PROVIDER_IDS[@]}" -eq 0 ]; then
-            echo "ERROR: no Machines found for cluster 'test'"
-            kubectl get machines -A
-            exit 1
-          fi
-
-          BAD_TOKENS='nofb|nomodeset|gfxpayload=text'
-          for provider_id in "${PROVIDER_IDS[@]}"; do
-            [ -n "${provider_id}" ] || continue
-            instance_id="${provider_id##*/}"
-
-            echo "Instance ID: ${instance_id} (providerID: ${provider_id})"
-            LOG=$(openstack console log show "${instance_id}")
-
-            if [ -z "${LOG//[[:space:]]/}" ]; then
-              echo "ERROR: console log is empty for instance ${instance_id}"
-              exit 1
-            fi
-
-            if ! grep -qE 'Kernel command line:' <<<"${LOG}"; then
-              echo "ERROR: no 'Kernel command line:' entry found in console log for instance ${instance_id}"
-              echo "${LOG}"
-              exit 1
-            fi
-            if ! grep -qE '(^|\] )Command line:' <<<"${LOG}"; then
-              echo "ERROR: no 'Command line:' entry found in console log for instance ${instance_id}"
-              echo "${LOG}"
-              exit 1
-            fi
-
-            if grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -Eq "${BAD_TOKENS}"; then
-              echo "ERROR: forbidden kernel cmdline tokens (${BAD_TOKENS}) found for instance ${instance_id}:"
-              grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" | grep -E "${BAD_TOKENS}"
-              exit 1
-            fi
-
-            echo "Kernel cmdline entries:"
-            grep -E '(Kernel command line|(^|\] )Command line):' <<<"${LOG}" || true
-          done
-        env:
-          OS_CLOUD: devstack
 
       - name: Start CI debugging on failures
         uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1.14.0

--- a/elements/kubernetes/environment.d/10-kubernetes
+++ b/elements/kubernetes/environment.d/10-kubernetes
@@ -6,6 +6,7 @@ export DIB_KUBELET_VERSION=${DIB_KUBERNETES_VERSION}
 export DIB_KUBECTL_VERSION=${DIB_KUBERNETES_VERSION}
 
 # NOTE(fitbeard): Avoid adding any default kernel options defined by diskimage-builder.
-#                 It defaults to 'nofb nomodeset gfxpayload=text' which prevents GPU
-#                 driver loading.
-export DIB_BOOTLOADER_DEFAULT_CMDLINE=" "
+#                 'DIB_BOOTLOADER_DEFAULT_CMDLINE' defaults to 'nofb nomodeset gfxpayload=text'
+#                 which prevents GPU drivers to load.
+export DIB_KUBERNETES_BOOTLOADER_DEFAULT_CMDLINE=${DIB_KUBERNETES_BOOTLOADER_DEFAULT_CMDLINE:-" "}
+export DIB_BOOTLOADER_DEFAULT_CMDLINE=${DIB_KUBERNETES_BOOTLOADER_DEFAULT_CMDLINE}

--- a/elements/kubernetes/environment.d/10-kubernetes
+++ b/elements/kubernetes/environment.d/10-kubernetes
@@ -4,3 +4,8 @@ export DIB_KUBERNETES_VERSION=${DIB_KUBERNETES_VERSION:-"1.36.0"}
 export DIB_KUBEADM_VERSION=${DIB_KUBERNETES_VERSION}
 export DIB_KUBELET_VERSION=${DIB_KUBERNETES_VERSION}
 export DIB_KUBECTL_VERSION=${DIB_KUBERNETES_VERSION}
+
+# NOTE(fitbeard): Avoid adding any default kernel options defined by diskimage-builder.
+#                 It defaults to 'nofb nomodeset gfxpayload=text' which prevents GPU
+#                 driver loading.
+export DIB_BOOTLOADER_DEFAULT_CMDLINE=" "


### PR DESCRIPTION
Related: https://github.com/vexxhost/capo-image-elements/issues/159

TL;DR: diskiamge-builder bootloader DIB always adds new lines at the end of grub config so if anything is provided earlier by distribution it will be ignored - last lines always wins.

```
...
# If you change this file, run 'update-grub' afterwards to update
# /boot/grub/grub.cfg.
# For full documentation of the options in this file, see:
#   info -f grub -n 'Simple configuration'

GRUB_DEFAULT=0
GRUB_TIMEOUT_STYLE=menu
GRUB_TIMEOUT=5
GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
GRUB_CMDLINE_LINUX=""

# Uncomment to enable BadRAM filtering, modify to suit your needs
# This works with Linux (no patch required) and with any kernel that obtains
# the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
#GRUB_BADRAM="0x01234567,0xfefefefe,0x89abcdef,0xefefefef"

# Uncomment to disable graphical terminal (grub-pc only)
#GRUB_TERMINAL=console

# The resolution used on graphical terminal
# note that you can use only modes which your graphic card supports via VBE
# you can see them in real GRUB with the command `vbeinfo'
#GRUB_GFXMODE=640x480

# Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux
#GRUB_DISABLE_LINUX_UUID=true

# Uncomment to disable generation of recovery mode menu entries
#GRUB_DISABLE_RECOVERY="true"

# Uncomment to get a beep at grub start
#GRUB_INIT_TUNE="480 440 1"
GRUB_DEVICE=LABEL=cloudimg-rootfs
GRUB_DISABLE_LINUX_UUID=true
GRUB_TERMINAL="serial console"
GRUB_GFXPAYLOAD_LINUX=auto
GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS0,115200 no_timer_check nofb nomodeset gfxpayload=text"
GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
...
```
We need to create a workaround here - pass empty space to override default:
```
DIB_BOOTLOADER_DEFAULT_CMDLINE=${DIB_BOOTLOADER_DEFAULT_CMDLINE:-"nofb nomodeset gfxpayload=text"}
```

Regarding serial console settings we are safeguarded by `GRUB_SERIAL_COMMAND` default setting.