### PR TITLE
Remove nfs-common and rsyslog from package installs

### DIFF
--- a/elements/kubernetes/package-installs.yaml
+++ b/elements/kubernetes/package-installs.yaml
@@ -12,8 +12,6 @@ linux-firmware:
   when: DISTRO_NAME != debian
 logrotate:
 lvm2:
-nfs-common:
-rsyslog:
 # NOTE(fitbeard): Use plain systemd-networkd for Debian and Rocky Linux.
 systemd-networkd:
   when: DISTRO_NAME = rocky

--- a/elements/kubernetes/pkg-map
+++ b/elements/kubernetes/pkg-map
@@ -1,7 +1,0 @@
-{
-  "family": {
-    "redhat": {
-      "nfs-common": "nfs-utils"
-    }
-  }
-}


### PR DESCRIPTION
This shrinks the image, and reduce used memory.

- rpcbind and blkmapd (from nfs-common) consume >5Mi
- rsyslog consumes >5Mi