### PR TITLE
Configure kube-reserved cgroup

### DIFF
--- a/elements/containerd/element-deps
+++ b/elements/containerd/element-deps
@@ -1,1 +1,2 @@
 dib-init-system
+podruntime-slice

--- a/elements/containerd/init-scripts/systemd/containerd.service
+++ b/elements/containerd/init-scripts/systemd/containerd.service
@@ -18,6 +18,7 @@ Documentation=https://containerd.io
 After=network.target dbus.service
 
 [Service]
+Slice=podruntime.slice
 ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd
 

--- a/elements/kubelet/element-deps
+++ b/elements/kubelet/element-deps
@@ -1,2 +1,3 @@
 dib-init-system
 install-static
+podruntime-slice

--- a/elements/kubelet/init-scripts/systemd/kubelet.service
+++ b/elements/kubelet/init-scripts/systemd/kubelet.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Slice=podruntime.slice
 ExecStart=/usr/bin/kubelet
 Restart=always
 StartLimitInterval=0

--- a/elements/podruntime-slice/element-deps
+++ b/elements/podruntime-slice/element-deps
@@ -1,0 +1,1 @@
+dib-init-system

--- a/elements/podruntime-slice/init-scripts/systemd/podruntime.slice
+++ b/elements/podruntime-slice/init-scripts/systemd/podruntime.slice
@@ -1,0 +1,7 @@
+[Unit]
+Description=Limited resources slice for Kubernetes services
+Documentation=man:systemd.special(7)
+DefaultDependencies=no
+Before=slices.target
+Requires=-.slice
+After=-.slice


### PR DESCRIPTION
References:

- https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
- https://github.com/kubernetes/design-proposals-archive/blob/main/node/node-allocatable.md#recommended-cgroups-setup
- https://soc.meschbach.com/posts/2022/07/30-cgroups-kubernetes-and-reliable-nodes/

What is missing:

- `kubeReservedCgroup: /podruntime.slice` is not set, because this should go in [KubeletConfiguration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration) IMO